### PR TITLE
add macOS guidance

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,11 @@ For Linux (tested on Arch Linux):
 sudo pip install -r requirements.txt
 ```
 
+For macOS (tested on macOS 14.x, arm64, Python 3.8)
+```
+python -m pip install -r requirements.txt
+```
+
 执行 ```akamTester.py```
 ```
 python3 akamTester.py


### PR DESCRIPTION
It couldn't build the environment with Python 3.11 for some compiler reasons while building wheels. 

Didn't have time to dig into the issue, but Python 3.8 would work just fine.

